### PR TITLE
generic_visit happens before real evaluation

### DIFF
--- a/attest/collectors.py
+++ b/attest/collectors.py
@@ -224,7 +224,8 @@ class Tests(object):
         return suite
 
     def run(self, reporter=auto_reporter,
-            full_tracebacks=False, fail_fast=False, debugger=False):
+            full_tracebacks=False, fail_fast=False, debugger=False,
+            ipdb_debugger=False):
         """Run all tests in this collection.
 
         :param reporter:
@@ -237,6 +238,8 @@ class Tests(object):
             Stop after the first failure.
         :param debugger:
             Enter PDB when tests fail.
+        :param ipdb_debugger:
+            Enter IPDB when tests fail.
 
         .. versionchanged:: 0.6 Added `full_tracebacks` and `fail_fast`.
 
@@ -247,7 +250,7 @@ class Tests(object):
         reporter.begin(self._tests)
         for test in self:
             result = TestResult(test=test, full_tracebacks=full_tracebacks,
-                                debugger=debugger)
+                                debugger=debugger, ipdb_debugger=ipdb_debugger)
             try:
                 with capture_output() as (out, err):
                     if test() is False:

--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -48,6 +48,7 @@ class TestResult(object):
     full_tracebacks = False
 
     debugger = False
+    ipdb_debugger = False
 
     #: The test callable.
     test = None
@@ -69,6 +70,10 @@ class TestResult(object):
             import pdb
             tb = self.exc_info[2]
             pdb.post_mortem(tb)
+        elif self.ipdb_debugger:
+            import ipdb
+            tb = self.exc_info[2]
+            ipdb.post_mortem(tb)
 
     @property
     def test_name(self):

--- a/attest/run.py
+++ b/attest/run.py
@@ -35,6 +35,10 @@ def make_parser(**kwargs):
                 action='store_true',
                 help='enter pdb for failing tests',
             ),
+            make_option('-i', '--ipdb-debugger',
+                action='store_true',
+                help='enter ipdb for failing tests',
+            ),
             make_option('-r', '--reporter',
                 metavar='NAME',
                 help='select reporter by name'
@@ -88,7 +92,8 @@ def main(tests=None, **kwargs):
 
     tests.run(reporter, full_tracebacks=options.full_tracebacks,
                         fail_fast=options.fail_fast,
-                        debugger=options.debugger)
+                        debugger=options.debugger,
+                        ipdb_debugger=options.ipdb_debugger)
 
 
 if __name__ == '__main__':

--- a/attest/tests/hook.py
+++ b/attest/tests/hook.py
@@ -18,6 +18,8 @@ def eval():
     }
 
     for expr, result in samples.iteritems():
-        ev = repr(ExpressionEvaluator(expr, globals(), locals()))
+        expr = ExpressionEvaluator(expr, globals(), locals())
+        expr.late_visit()
+        ev = repr(expr)
         assert ev == result
         assert bool(ev) is True


### PR DESCRIPTION
I was testing a project with attest when I ran into this situation:
With assert hooks,

```
assert a_function() == 2
```

will cause a_function to be called twice.
Furthermore assert will fail in this case : https://gist.github.com/1028057 as assert_hook will evaluate the function before the real assert (which can change the returned value of a function) and say :

```
TestFailure
assert (c() == 2)
assert (2 == 2)
```

So I moved the visit call after the **nonzero** evaluation to fix this case and only if the test fails to avoid double evaluation of heavy functions.
All attest tests pass with the little tests/hook.py modification.

Best regards
