### PR TITLE
Add missing pow operator

### DIFF
--- a/attest/ast.py
+++ b/attest/ast.py
@@ -37,6 +37,7 @@ BINOP_SYMBOLS = {
     Add:        '+',
     Sub:        '-',
     Mult:       '*',
+    Pow:        '**',
     Div:        '/',
     FloorDiv:   '//',
     Mod:        '%',


### PR DESCRIPTION
Attest crash with :

```
File "…/attest/hook.py", line 291, in load_module
    raise ImportError('cannot import %s: %s' % (name, err))
ImportError: cannot import module_name: <class '_ast.Pow'>
```

when a file has a '**' operator.

Adding it to ast symbols seems to fix that
