### PR TITLE
Fix undefined var in closure

### DIFF
--- a/attest/hook.py
+++ b/attest/hook.py
@@ -48,7 +48,11 @@ class ExpressionEvaluator(SourceGenerator):
 
     def __init__(self, expr, globals, locals):
         self.expr = expr
-        self.globals, self.locals = globals, locals
+        # Putting locals in globals for closures
+        self.globals = dict(globals)
+        self.locals = locals
+        self.globals.update(self.locals)
+
         self.result = []
         self.node = ast.parse(self.expr).body[0].value
 


### PR DESCRIPTION
When asserting with something in closure, I get this behaviour:

```
otherthing = "sthg"
assert all(item.something == otherthing for item in items)

NameError: global name 'otherthing' is not defined
```

This is because python compile doesn't know about the closure and therefore consider it as a global references.
Putting locals in globals fixes this problem
