### PR TITLE
No capture flag

### DIFF
--- a/attest/collectors.py
+++ b/attest/collectors.py
@@ -224,7 +224,8 @@ class Tests(object):
         return suite
 
     def run(self, reporter=auto_reporter,
-            full_tracebacks=False, fail_fast=False, debugger=False):
+            full_tracebacks=False, fail_fast=False,
+            debugger=False, no_capture=False):
         """Run all tests in this collection.
 
         :param reporter:
@@ -249,9 +250,14 @@ class Tests(object):
             result = TestResult(test=test, full_tracebacks=full_tracebacks,
                                 debugger=debugger)
             try:
-                with capture_output() as (out, err):
+                out, err = [], []
+                if no_capture:
                     if test() is False:
                         raise AssertionError('test() is False')
+                else:
+                    with capture_output() as (out, err):
+                        if test() is False:
+                            raise AssertionError('test() is False')
             except BaseException, e:
                 if isinstance(e, KeyboardInterrupt):
                     break

--- a/attest/run.py
+++ b/attest/run.py
@@ -43,6 +43,10 @@ def make_parser(**kwargs):
                 action='store_true',
                 help='list available reporters'
             ),
+            make_option('-n', '--no-capture',
+                action='store_true',
+                help="don't capture stderr and stdout"
+            ),
             make_option('--full-tracebacks',
                 action='store_true',
                 help="don't clean tracebacks"
@@ -88,7 +92,8 @@ def main(tests=None, **kwargs):
 
     tests.run(reporter, full_tracebacks=options.full_tracebacks,
                         fail_fast=options.fail_fast,
-                        debugger=options.debugger)
+                        debugger=options.debugger,
+                        no_capture=options.no_capture)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Introduce a no-capture cli flag (-n, --no-capture) to allow printing and pdb-ing everywhere (useful for debugging)
