### PR TITLE
Use unittest’s type-specific comparaisons on failed "assert a == b"

### DIFF
--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -342,7 +342,8 @@ class FancyReporter(AbstractReporter):
     def finished(self):
         from pygments.console import colorize
         from pygments import highlight
-        from pygments.lexers import PythonTracebackLexer, PythonLexer
+        from pygments.lexers import (PythonTracebackLexer, PythonLexer,
+                                     DiffLexer)
 
         if self.style in ('light', 'dark'):
             from pygments.formatters import TerminalFormatter
@@ -392,7 +393,7 @@ class FancyReporter(AbstractReporter):
 
             equality_diff = result.equality_diff
             if equality_diff is not None:
-                print equality_diff
+                print highlight(equality_diff, DiffLexer(), formatter)
 
             result.debug()
 

--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -130,6 +130,8 @@ class TestResult(object):
 
     @property
     def equality_diff(self):
+        if not isinstance(self.error, TestFailure):
+            return
         # Create a dummy test case to use its assert* methods
         case = unittest.FunctionTestCase(lambda: None)
         # Type-specific methods are only available since Python 2.7


### PR DESCRIPTION
Since Python 2.7 unittest’s assertEquals has some type-specific output on failures. For example with sets, it will list elements that are in one set and not the other.

This patch re-uses unittest’s functions to print the same output when the ast for a failed assertion looks like "a == b".
