### PR TITLE
Add a --profile option profiling test runs but not imports.

### DIFF
--- a/attest/collectors.py
+++ b/attest/collectors.py
@@ -291,6 +291,9 @@ class Tests(object):
         ``-l``, ``--list-reporters``
             List the names of all installed reporters
 
+        ``-p FILENAME``, ``--profile FILENAME``
+            Run the tests in cProfile and store the results in FILENAME
+
 
         Remaining arguments are passed to the reporter.
 

--- a/attest/run.py
+++ b/attest/run.py
@@ -59,6 +59,10 @@ def make_parser(**kwargs):
                 action='store_true',
                 help="don't hook the assert statement"
             ),
+            make_option('-p', '--profile',
+                metavar='FILENAME',
+                help='enable tests profiling and store results in filename'
+            ),
         ]
     )
     args.update(kwargs)
@@ -90,10 +94,19 @@ def main(tests=None, **kwargs):
             with AssertImportHook():
                 tests = Tests(names)
 
-    tests.run(reporter, full_tracebacks=options.full_tracebacks,
-                        fail_fast=options.fail_fast,
-                        debugger=options.debugger,
-                        no_capture=options.no_capture)
+    def run():
+        tests.run(reporter, full_tracebacks=options.full_tracebacks,
+                            fail_fast=options.fail_fast,
+                            debugger=options.debugger,
+                            no_capture=options.no_capture)
+
+    if options.profile:
+        filename = options.profile
+        import cProfile
+        cProfile.runctx('run()', globals(), locals(), filename)
+        print 'Wrote profiling results to %r.' % (filename,)
+    else:
+        run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
One can user "python -m cProfile $(which attest)" to profile tests run by Attest, but this also profiles the importing and AST-rewriting of tests, which I did not want.

This patch adds an option to run just the tests themselves in cProfile and store the results in a file. This file is meant to be used with the pstats module as described on http://docs.python.org/library/profile.html
