### PR TITLE
Raise size limit on diff size for type-specific comparaisons.

### DIFF
--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -134,6 +134,7 @@ class TestResult(object):
             return
         # Create a dummy test case to use its assert* methods
         case = unittest.FunctionTestCase(lambda: None)
+        case.maxDiff = 2000
         # Type-specific methods are only available since Python 2.7
         if hasattr(case, '_type_equality_funcs'):
             node = self.error.value.node


### PR DESCRIPTION
unittest2’s type-specific diffs have a size limit set fairly low by default. This raises the limit to still profit from the diff on big outputs, where it is most needed.
