### PR TITLE
Added a check for sys.stdout has attribute isatty. Some IDE's replace sys

### DIFF
--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -438,7 +438,7 @@ def auto_reporter(**opts):
         :meth:`AbstractReporter.test_loader`.
 
     """
-    if sys.stdout.isatty():
+    if hasattr(sys.stdout, 'isatty') and sys.stdout.isatty():
         try:
             return FancyReporter(**opts)
         except ImportError:


### PR DESCRIPTION
Added a check for sys.stdout has attribute isatty. Some IDE's replace sys.stdout with graphical replacement and may miss this attribute, which results in a error message, instead of PlainReporter being chosen.

Fix for issue #125
