### PR TITLE
Do not fail trying to compare dicts under Python >= 2.7

### DIFF
--- a/attest/reporters.py
+++ b/attest/reporters.py
@@ -158,6 +158,8 @@ class TestResult(object):
                 if type(left) is type(right):
                     asserter = case._type_equality_funcs.get(type(left))
                     if asserter is not None:
+                        if isinstance(asserter, basestring):
+                            asserter = getattr(case, asserter)
                         try:
                             asserter(left, right)
                         except AssertionError, exc:


### PR DESCRIPTION
_type_equality_funcs registers names of functions, not the functions themselves, so do an extra step to obtain actual comparers.
