### PR TITLE
Add AssertImportHook.is_package() method

### DIFF
--- a/attest/hook.py
+++ b/attest/hook.py
@@ -338,6 +338,10 @@ class AssertImportHook(object):
         source = self.get_source(name)
         filename = self.get_filename(name)
 
+        if filename is None:
+            # when it's builtin or extension
+            return None
+
         if source:
             code = compile(source, filename, 'exec')
         else:

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -318,14 +318,14 @@ class AssertImportHook(object):
         try:
             (fd, fn, info), path = self._cache[name]
         except KeyError:
-            return ImportError(name)
+            raise ImportError(name)
         return info[2] == imp.PKG_DIRECTORY
 
     def get_filename(self, name):
         try:
             (fd, fn, info), path = self._cache[name]
         except KeyError:
-            return ImportError(name)
+            raise ImportError(name)
 
         if info[2] == imp.PY_SOURCE:
             return fn

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -316,3 +316,10 @@ class AssertImportHook(object):
                 code = f.read()
 
         return code, filename, newpath
+
+    def is_package(self, name):
+        try:
+            (fd, fn, info), path = self._cache[name]
+        except KeyError:
+            return False
+        return info[2] == imp.PKG_DIRECTORY

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -330,9 +330,12 @@ class AssertImportHook(object):
         except KeyError:
             return ImportError(name)
 
+        filename = None
         if info[2] == imp.PY_SOURCE:
-            return fn
+            filename = fn
         elif info[2] == imp.PY_COMPILED:
-            return fn[:-1]
+            filename = fn[:-1]
         elif info[2] == imp.PKG_DIRECTORY:
-            return os.path.join(fn, '__init__.py')
+            filename = os.path.join(fn, '__init__.py')
+
+        return filename

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -321,5 +321,5 @@ class AssertImportHook(object):
         try:
             (fd, fn, info), path = self._cache[name]
         except KeyError:
-            return False
+            return ImportError(name)
         return info[2] == imp.PKG_DIRECTORY

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -307,17 +307,12 @@ class AssertImportHook(object):
         except KeyError:
             raise ImportError(name)
 
-        code = None
         if info[2] == imp.PY_SOURCE:
             with fd:
-                code = fd.read()
-        elif info[2] == imp.PY_COMPILED:
-            code = None
+                return fd.read()
         elif info[2] == imp.PKG_DIRECTORY:
             with open(self.get_filename(name), 'U') as f:
-                code = f.read()
-
-        return code
+                return f.read()
 
     def is_package(self, name):
         try:
@@ -332,15 +327,12 @@ class AssertImportHook(object):
         except KeyError:
             return ImportError(name)
 
-        filename = None
         if info[2] == imp.PY_SOURCE:
-            filename = fn
+            return fn
         elif info[2] == imp.PY_COMPILED:
-            filename = fn[:-1]
+            return fn[:-1]
         elif info[2] == imp.PKG_DIRECTORY:
-            filename = os.path.join(fn, '__init__.py')
-
-        return filename
+            return os.path.join(fn, '__init__.py')
 
     def get_code(self, name):
         source = self.get_source(name)

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -339,7 +339,7 @@ class AssertImportHook(object):
         filename = self.get_filename(name)
 
         if source:
-            code = compile(source, filename)
+            code = compile(source, filename, 'exec')
         else:
             with open(filename, 'rb') as f:
                 f.seek(8)

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 
 import imp
 import inspect
+import marshal
 import os
 import sys
 
@@ -340,3 +341,16 @@ class AssertImportHook(object):
             filename = os.path.join(fn, '__init__.py')
 
         return filename
+
+    def get_code(self, name):
+        source = self.get_source(name)
+        filename = self.get_filename(name)
+
+        if source:
+            code = compile(source, filename)
+        else:
+            with open(filename, 'rb') as f:
+                f.seek(8)
+                code = marshal.load(f)
+
+        return code

--- a/attest/hook.py
+++ b/attest/hook.py
@@ -323,3 +323,16 @@ class AssertImportHook(object):
         except KeyError:
             return ImportError(name)
         return info[2] == imp.PKG_DIRECTORY
+
+    def get_filename(self, name):
+        try:
+            (fd, fn, info), path = self._cache[name]
+        except KeyError:
+            return ImportError(name)
+
+        if info[2] == imp.PY_SOURCE:
+            return fn
+        elif info[2] == imp.PY_COMPILED:
+            return fn[:-1]
+        elif info[2] == imp.PKG_DIRECTORY:
+            return os.path.join(fn, '__init__.py')

--- a/attest/tests/hook.py
+++ b/attest/tests/hook.py
@@ -1,5 +1,7 @@
+import types
+
 from attest import Tests, assert_hook
-from attest.hook import ExpressionEvaluator
+from attest.hook import AssertImportHook, ExpressionEvaluator
 
 
 suite = Tests()
@@ -31,3 +33,10 @@ def initpy_with_relative_import():
     # Ensure that packages with an __init__.py file that use both assert_hook
     # and relative imports are hooked properly.
     from . import dummy
+
+
+@suite.test
+def get_code():
+    loader = AssertImportHook()
+    loader.find_module('StringIO')
+    assert isinstance(loader.get_code('StringIO'), types.CodeType)

--- a/attest/tests/hook.py
+++ b/attest/tests/hook.py
@@ -38,5 +38,9 @@ def initpy_with_relative_import():
 @suite.test
 def get_code():
     loader = AssertImportHook()
+    loader.find_module('sys')
+    assert loader.get_code('sys') is None
+    loader.find_module('cStringIO')
+    assert loader.get_code('cStringIO') is None
     loader.find_module('StringIO')
     assert isinstance(loader.get_code('StringIO'), types.CodeType)


### PR DESCRIPTION
Although implementing `.is_package()` is [optional according to PEP 302](http://www.python.org/dev/peps/pep-0302/#optional-extensions-to-the-importer-protocol), it makes several Python codes that assume every import hook implements this method (e.g. [Flask](https://github.com/mitsuhiko/flask/blob/0.9/flask/helpers.py#L727)) to work well with Attest.
