### PR TITLE
Make sure FancyReporter detects encoding of the traceback messages.

### DIFF
--- a/attest/tests/reporters.py
+++ b/attest/tests/reporters.py
@@ -1,3 +1,4 @@
+# coding:utf-8
 from __future__ import with_statement
 
 import sys
@@ -111,3 +112,24 @@ def quickfix_reporter():
             _meta.suite.run(attest.QuickFixReporter)
 
     assert out == ['%s:%d: TestFailure' % (SOURCEFILE, LINENO)]
+
+
+@suite.test_if(COMPILES_AST)
+def fancy_reporter_detects_encoding():
+    """FancyReporter should detect code encoding."""
+
+    from pygments.style import Style
+    class NoStyle(Style):
+        default_style = ''
+        styles = {}
+
+    suite_ = Tests()
+    @suite_.test
+    def unicode_failing():
+        assert u'유니코드' == u'테스트'
+
+    with attest.capture_output() as (out, err):
+        with Assert.raises(SystemExit):
+            suite_.run(attest.FancyReporter(NoStyle))
+
+    assert 'assert u\'유니코드\' == u\'테스트\'' in map(str.strip, out)


### PR DESCRIPTION
Hi Dag,

I'm going to use Attest==0.5.3 instead of Unittest for [my project focused on Korean language](https://github.com/sublee/korean). So my test suites contain many Hangul characters (non-ASCII) and are hinted encoding by `# -*- coding: utf-8 -*-`. But traceback message of FancyReporter is broken because it doesn't aware the encoding of the test code.

```
# -*- coding: utf-8 -*-
from attest import Tests, assert_hook

suite = Tests()

@suite.test
def unicode_failing():
    assert u'유니코드' == u'테스트'
```

The output will be broken:

```
[100%] 1 of 1 Time: 0:00:00

koreantests.unicode_failing
--------------------------------------------------------------------------------
Traceback (most recent call last):
  File "koreantests.py", line 7, in unicode_failing
    assert u'ì ëì½ë' == u'í
ì¤í¸'
TestFailure

assert (u'\uc720\ub2c8\ucf54\ub4dc' == u'\ud14c\uc2a4\ud2b8')
assert (u'\uc720\ub2c8\ucf54\ub4dc' == u'\ud14c\uc2a4\ud2b8')

Failures: 1/1 (1 assertions)
```

My patch provides the code encoding detector for fix broken messages of FancyReporter:

```
[100%] 1 of 1 Time: 0:00:00

koreantests.unicode_failing
--------------------------------------------------------------------------------
Traceback (most recent call last):
  File "koreantests.py", line 7, in unicode_failing
    assert u'유니코드' == u'테스트'
TestFailure

assert (u'\uc720\ub2c8\ucf54\ub4dc' == u'\ud14c\uc2a4\ud2b8')
assert (u'\uc720\ub2c8\ucf54\ub4dc' == u'\ud14c\uc2a4\ud2b8')

Failures: 1/1 (1 assertions)
```

Please review and accept this pull request if there's no problem.

Regards,
Heungsub
